### PR TITLE
Add reset_email stored procedure and changeEmail API

### DIFF
--- a/create_storyforge_db.sql
+++ b/create_storyforge_db.sql
@@ -92,6 +92,37 @@ END //
 
 DELIMITER ;
 
+DELIMITER //
+-- RESET EMAIL
+CREATE PROCEDURE reset_email(IN input_token CHAR(255), IN input_NewEmail VARCHAR(255))
+BEGIN
+    -- check exist
+    DECLARE emailExists INT;
+    DECLARE validToken INT;
+    DECLARE id INT;
+    -- Create a temporary table for response
+    CREATE TEMPORARY TABLE IF NOT EXISTS RESPONSE (
+        RESPONSE_STATUS VARCHAR(20),
+        RESPONSE_MESSAGE VARCHAR(255)
+    );
+    
+    SELECT COUNT(*) INTO emailExists FROM USER_LOGIN WHERE EMAIL = input_NewEmail;
+    SELECT COUNT(*) INTO validToken FROM TOKEN_TABLE WHERE TOKEN = input_token AND EXPIRY_TIME > UNIX_TIMESTAMP();
+    -- Insert the new user only if the email does not exist
+    IF emailExists > 0 THEN
+        INSERT INTO RESPONSE VALUES ('Error', 'duplicateEmail');
+    ELSEIF validToken = 0 THEN
+        INSERT INTO RESPONSE VALUES ('Error', 'invalidToken');
+    ELSE
+        -- Insert the new user if the email does not exist
+        SELECT USER_ID INTO id FROM TOKEN_TABLE WHERE TOKEN = input_token;
+        UPDATE USER_LOGIN SET EMAIL = input_NewEmail WHERE USER_ID = id;
+        INSERT INTO RESPONSE VALUES ('Success', 'updatedEmail');
+    END IF;
+    SELECT * FROM RESPONSE;
+    DROP TEMPORARY TABLE RESPONSE;
+END //
+DELIMITER ;
 
 DELIMITER //
 CREATE PROCEDURE validate_user(IN input_email VARCHAR(255), IN input_pass VARCHAR(255))
@@ -140,7 +171,9 @@ DO
 
 
 -- testing add user
+CALL insert_user_login('admin', 'admin123');
 CALL insert_user_login('test', 'testing123');
 CALL insert_user_login('test2', 'testing123');
 -- testing validate user
 -- CALL validate_user('test', 'testing123');
+-- CALL validate_user('test2', 'testing123');

--- a/create_storyforge_db.sql
+++ b/create_storyforge_db.sql
@@ -109,10 +109,10 @@ BEGIN
     SELECT COUNT(*) INTO emailExists FROM USER_LOGIN WHERE EMAIL = input_NewEmail;
     SELECT COUNT(*) INTO validToken FROM TOKEN_TABLE WHERE TOKEN = input_token AND EXPIRY_TIME > UNIX_TIMESTAMP();
     -- Insert the new user only if the email does not exist
-    IF emailExists > 0 THEN
-        INSERT INTO RESPONSE VALUES ('Error', 'duplicateEmail');
-    ELSEIF validToken = 0 THEN
+    IF validToken = 0 THEN
         INSERT INTO RESPONSE VALUES ('Error', 'invalidToken');
+    ELSEIF emailExists > 0 THEN
+        INSERT INTO RESPONSE VALUES ('Error', 'duplicateEmail');
     ELSE
         -- Insert the new user if the email does not exist
         SELECT USER_ID INTO id FROM TOKEN_TABLE WHERE TOKEN = input_token;

--- a/server.js
+++ b/server.js
@@ -104,6 +104,38 @@ app.post("/api/users/signup", (req, res) => {
 	});
 });
 
+
+// *===========================================================*
+// |                	CHANGE EMAIL API           			   |
+// *===========================================================*
+// Incoming: { token, newEmail }
+// Outgoing: { status }
+app.post("/api/users/changeEmail", (req, res) => {
+    const { token, newEmail } = req.body;
+    if (!token || !newEmail) {
+        return res.status(400).json({ error: "missingFields" });
+    }
+
+    var data = sanitizeData({ token, newEmail });
+
+    const sql = "CALL reset_email(?, ?)";
+    const params = [data.token, data.newEmail];
+    db.query(sql, params, function (err, result) {
+        // Handle SQL error
+        if (err) {
+            return res.status(400).json({ error: "sqlError" });
+        }
+
+        //extract the response from the stored procedure
+        const response = result[0][0];
+
+        if (response.RESPONSE_STATUS === "Error") {
+            return res.status(400).json({ error: response.RESPONSE_MESSAGE });
+        }
+        return res.status(200).json(response.RESPONSE_MESSAGE);
+    });
+});
+
 function sanitizeData(data) {
 	if (typeof data === "string") {
 		// String sanitization


### PR DESCRIPTION
## Overall Description:

- added a changeEmail api endpoint
- added change email stored procedure

## What Was Changed:

- server.js so i could add the api endpoint
- sql table so i could add the procedure

## Any Notes For Testing:

- Rebuild database
- start server and front end
- login with the new admin user, email: "admin", password: "admin123"
- open console log and copy the token into a API request to http://localhost:3000/api/users/changeEmail
- API Request: "token":"{val copied above}", "newEmail":"{whateverYouWant}"
- After each run http://localhost:2363/api/users/ and note whether email has changed
- try with an invalid token too
 i would suggest trying empty, test1, random keys etc to see diff errors.


## Link To Ticket:

https://trello.com/c/BDwazgXZ/45-set-up-updateemail

## Screenshots of change
<img width="1002" alt="image" src="https://github.com/Quickzand/StoryForge/assets/99466378/2e564915-852a-473b-bfb0-f33661a0d6a0">
<img width="995" alt="image" src="https://github.com/Quickzand/StoryForge/assets/99466378/98d7d823-47bc-4e17-8e68-83160e1a1308">
<img width="999" alt="image" src="https://github.com/Quickzand/StoryForge/assets/99466378/aa0bef7f-01df-4366-ad88-2fc4ce7d7444">
<img width="1000" alt="image" src="https://github.com/Quickzand/StoryForge/assets/99466378/24705115-b853-4030-b389-6c2f15e109e8">

